### PR TITLE
add future keyboard topics to blog

### DIFF
--- a/microkeebs/.changeset/add-blog-keyboards.md
+++ b/microkeebs/.changeset/add-blog-keyboards.md
@@ -1,0 +1,5 @@
+---
+"microkeebs": minor
+---
+
+Added subtle keyboard list to Blog component.

--- a/microkeebs/src/components/Blog.tsx
+++ b/microkeebs/src/components/Blog.tsx
@@ -16,6 +16,18 @@ export function Blog() {
         }`}>
           Keep an eye out
         </p>
+        
+        <div className={`mt-16 text-sm font-medium tracking-wide ${
+          isDark ? 'text-[#a7a495]/30' : 'text-[#1c1c1c]/30'
+        }`}>
+          <ul className="flex flex-col gap-2">
+            <li>TGR Jane V2 CE</li>
+            <li>Toro60</li>
+            <li>Diversity TKL</li>
+            <li>HHKB Pro 2</li>
+            <li>Geonworks F1-8X V2</li>
+          </ul>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Added a subtle list of keyboards to the blog area to maintain the 'nothing here yet' aesthetic.