### PR TITLE
fix: add Content-Security-Policy for external resources

### DIFF
--- a/quarzite/index.html
+++ b/quarzite/index.html
@@ -51,6 +51,9 @@
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>Quarzite</title>
 
+    <!-- Content Security Policy - allows unpkg.com for 98.css and sleepie.uk for oneko.js -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://www.youtube.com https://s.ytimg.com https://sleepie.uk; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://unpkg.com; img-src 'self' data: https:; font-src 'self' https://fonts.googleapis.com; connect-src 'self' https://micr.dev https://unpkg.com https://sleepie.uk; frame-src 'self' https://www.youtube.com https://micr.dev;">
+
     <!-- Favicon -->
     <link
       rel="icon"


### PR DESCRIPTION
Fixes CSP violations blocking 98.css and oneko.js

- Add https://unpkg.com to style-src (allows 98.css)
- Add https://sleepie.uk to script-src (allows oneko.js)  
- Add https://micr.dev to frame-src (allows site embedding)
- Resolves Content Security Policy violations in browser console