### PR TITLE
fix: allow quarzite assets in Netlify CSP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -207,8 +207,8 @@ force = true
   for = "/*"
   [headers.values]
     Strict-Transport-Security = "max-age=31536000; includeSubDomains; preload"
-    X-Frame-Options = "DENY"
+    X-Frame-Options = "SAMEORIGIN"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "camera=(), microphone=(), geolocation=()"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://www.youtube.com https://s.ytimg.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https: blob:; frame-src 'self' https://www.youtube.com https://open.spotify.com https://jspaint.app https://anonqmicr.netlify.app https://dialoguegen.vercel.app; object-src 'none';"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://www.youtube.com https://s.ytimg.com https://sleepie.uk; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://unpkg.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https: blob:; frame-src 'self' https://www.youtube.com https://open.spotify.com https://jspaint.app https://anonqmicr.netlify.app https://dialoguegen.vercel.app; object-src 'none';"

--- a/quarzite/index.html
+++ b/quarzite/index.html
@@ -51,9 +51,6 @@
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>Quarzite</title>
 
-    <!-- Content Security Policy - allows unpkg.com for 98.css and sleepie.uk for oneko.js -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://www.youtube.com https://s.ytimg.com https://sleepie.uk; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://unpkg.com; img-src 'self' data: https:; font-src 'self' https://fonts.googleapis.com; connect-src 'self' https://micr.dev https://unpkg.com https://sleepie.uk; frame-src 'self' https://www.youtube.com https://micr.dev;">
-
     <!-- Favicon -->
     <link
       rel="icon"


### PR DESCRIPTION
Production is enforcing CSP via Netlify response headers (netlify.toml), so the page-level meta CSP cannot unblock external resources.

Changes:
- Allow https://unpkg.com in style-src (98.css)
- Allow https://sleepie.uk in script-src (oneko)
- Change X-Frame-Options to SAMEORIGIN so micr.dev can be framed by same-origin pages